### PR TITLE
Clarify README calendar alignment details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Life Calendar is a lightweight script that creates printable PDFs visualizing every week of a lifetime. Inspired by Tim Urban's ["Your Life in Weeks" post](https://waitbutwhy.com/2014/05/life-weeks.html), it helps you reflect on the past and plan for the future at a glance.
 
+## Why this layout is different
+
+Traditional life calendars, such as Tim Urban's grid or [4kweeks](https://4kweeks.com/), assume exactly 52 weeks per year. Because a year is actually a little longer than 52 weeks, those grids gradually drift: your birthday creeps one cell to the right every few years, and after enough decades it can spill into the next row. That makes the row number diverge from your age (admittedly, you'd need around 300 birthdays before it loops, but here's to optimistic longevity!).
+
+This calendar keeps the first cell of every row aligned with the week of your birthday by inserting an extra week whenever it is needed. If you were born on a Monday, you fill each row starting on Mondays, and your birthday will always fall somewhere inside that first cell for its row. The dates shown on the left edge match the weekday of your birth on or before your birthday each year, keeping the birthday week anchored to the front of every row.
+
+In addition to preserving the alignment with your birthday, the calendar highlights major milestones by thickening the borders around every thousandth week (1k, 2k, 3k, …) and every gigasecond (1Gs, 2Gs, …).
+
 ## PDF examples
 
 * [Standard printable version](./static/life_calendar.pdf) — includes no pre-filled squares so you can mark them manually after printing.
@@ -37,3 +45,18 @@ To produce a blank printable calendar, omit the darkening flag:
 ```bash
 uv run https://raw.githubusercontent.com/martimlobao/life-calendar/main/life_calendar.py 1990-08-06 -a 100 -b "Martim Lobao"
 ```
+
+## FAQ
+
+**Why are there some rows with 53 cells?**  
+Those rows contain the inserted extra week that keeps the first cell aligned with your birthday. The additional cell compensates for the fact that years are slightly longer than exactly 52 weeks.
+
+**What are the dates on the left of the grid?**  
+They mark the calendar date for the weekday you were born on, pegged to the occurrence on or before your birthday each year. For example, if you arrived on a Wednesday, each label shows the Wednesday that lands on or just before your birthday, kicking off that year's birthday week.
+
+**What is the weekday at the top-left of the grid?**  
+It shows the weekday you were born on. Fill in each new week on that weekday to stay synchronized with your birthday.
+
+**What are the cells with thicker borders and the numbers/letters on the right side?**  
+Thicker borders highlight milestone weeks (1k, 2k, 3k, …) and milestone gigaseconds (1Gs, 2Gs, …). The labels on the right correspond to those milestones.
+


### PR DESCRIPTION
## Summary
- note that birthday drift happens every few years in traditional grids
- clarify that the left-edge dates mark your birth weekday on or before each birthday
- tighten the milestone highlight description by removing the celebratory aside

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e660e95da88331b967f8ee17f9bd68